### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,11 @@ import PackageDescription
 
 let package = Package(
     name: "MySQL",
-    dependencies: [
-        .Package(url: "https://github.com/novi/CMySQL-MariaDB.git", majorVersion: 2)
-    ],
     targets: [
                  Target(name: "SQLFormatter"),
                  Target(name: "MySQL", dependencies: ["SQLFormatter"])
-                 ]
+    ],
+    dependencies: [
+        .Package(url: "https://github.com/novi/CMySQL-MariaDB.git", majorVersion: 2)
+    ]
 )


### PR DESCRIPTION
/*/Packages/mysql-swift.git/Package.swift:8:5: error: argument 'targets' must precede argument 'dependencies'
    targets: [
    ^
Can't parse Package.swift manifest file because it contains invalid format. Fix Package.swift file format and try again.

_Edit_
using Xcode 8 GM
