### PR TITLE
Swift 4 Decodable pattern for basic queries

### DIFF
--- a/Sources/MySQL/Error.swift
+++ b/Sources/MySQL/Error.swift
@@ -18,6 +18,7 @@ public enum QueryError: Error {
     case fieldIndexOutOfBounds(fieldCount: Int, attemped: Int, fieldName: String)
     case castError(actualValue: String, expectedType: String, field: String)
     case initializationError
+    case initializationErrorMessage(message: String)
     case enumDecodeError
     case SQLStringDecodeError(error: Error, actualValue: String, expectedType: String, field: String)
     case missingField(field: String)

--- a/Sources/MySQL/Result.swift
+++ b/Sources/MySQL/Result.swift
@@ -142,3 +142,117 @@ public struct QueryRowResult {
         return try getValue(val: val, field: field)
     }    
 }
+
+// For Decodable pattern
+struct QueryRowResultDecoder : Decoder {
+    let codingPath = [CodingKey]()
+    let userInfo = [CodingUserInfoKey : Any]()
+    let row: QueryRowResult
+    
+    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        return KeyedDecodingContainer(RowKeyedDecodingContainer<Key>(decoder: self))
+    }
+    
+    public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        throw QueryError.initializationError
+    }
+    
+    public func singleValueContainer() throws -> SingleValueDecodingContainer {
+        throw QueryError.initializationError
+    }
+}
+
+// For Decodable pattern
+struct RowKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
+    typealias Key = K
+    
+    let decoder : QueryRowResultDecoder
+    
+    let allKeys = [Key]()
+    
+    let codingPath = [CodingKey]()
+    
+    func decodeNil(forKey key: K) throws -> Bool {
+        return false
+    }
+    
+    func contains(_ key: K) -> Bool {
+        return decoder.row.columnMap[key.stringValue] != nil
+    }
+    
+    func decode(_ type: Bool.Type, forKey key: K) throws -> Bool {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: Int.Type, forKey key: K) throws -> Int {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: Int8.Type, forKey key: K) throws -> Int8 {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: Int16.Type, forKey key: K) throws -> Int16 {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: Int32.Type, forKey key: K) throws -> Int32 {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: Int64.Type, forKey key: K) throws -> Int64 {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: UInt.Type, forKey key: K) throws -> UInt {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: UInt8.Type, forKey key: K) throws -> UInt8 {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: UInt16.Type, forKey key: K) throws -> UInt16 {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: UInt32.Type, forKey key: K) throws -> UInt32 {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: UInt64.Type, forKey key: K) throws -> UInt64 {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: Float.Type, forKey key: K) throws -> Float {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: Double.Type, forKey key: K) throws -> Double {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode(_ type: String.Type, forKey key: K) throws -> String {
+        return try decoder.row.getValue(forField: key.stringValue)
+    }
+    
+    func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T : Decodable {
+        throw QueryError.initializationError
+    }
+    
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> {
+        throw QueryError.initializationError
+    }
+    
+    func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+        throw QueryError.initializationError
+    }
+    
+    func superDecoder() throws -> Decoder {
+        throw QueryError.initializationError
+    }
+    
+    func superDecoder(forKey key: K) throws -> Decoder {
+        throw QueryError.initializationError
+    }
+}

--- a/Sources/MySQL/Result.swift
+++ b/Sources/MySQL/Result.swift
@@ -162,7 +162,6 @@ struct QueryRowResultDecoder : Decoder {
     }
 }
 
-// For Decodable pattern
 struct RowKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol {
     typealias Key = K
     
@@ -237,7 +236,11 @@ struct RowKeyedDecodingContainer<K : CodingKey> : KeyedDecodingContainerProtocol
     }
     
     func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T : Decodable {
-        throw QueryError.initializationError
+        if T.self is Data.Type {
+            // Bug: The compiler chooses NOT to use "decode() -> Data". We have to implement it in decode<T>()
+            return try decoder.row.getValue(forField: key.stringValue) as Data as! T
+        }
+        throw QueryError.castError(actualValue: "", expectedType: "Type \(T.self) not implemented" , field: key.stringValue)
     }
     
     func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> {

--- a/Tests/MySQLTests/Model.swift
+++ b/Tests/MySQLTests/Model.swift
@@ -32,6 +32,40 @@ struct SomeStringID: IDType {
     }
 }
 
+struct RowCodeable {
+    struct SimpleUser: Codable {
+        let id: UInt
+        let name: String
+        let age: Int
+    }
+    
+    struct UserDecodeWithKey: Decodable {
+        let id: Int? // AutoincrementID for Decodeable not implemented
+        
+        let name: String
+        let age: Int
+        let createdAt: Date
+        
+        let nameOptional: String?
+        let ageOptional: Int?
+        let createdAtOptional: Date?
+        
+        let done: Bool
+        let doneOptional: Bool?
+        
+        enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case age
+            case createdAt = "created_at"
+            case nameOptional = "name_Optional"
+            case ageOptional = "age_Optional"
+            case createdAtOptional = "created_at_Optional"
+            case done
+            case doneOptional = "done_Optional"
+        }
+    }
+}
 
 struct Row {
     

--- a/Tests/MySQLTests/QueryTests.swift
+++ b/Tests/MySQLTests/QueryTests.swift
@@ -167,6 +167,7 @@ class QueryTests: XCTestCase, QueryTestType {
         
         // fetch inserted rows
         try selectingWithFieldKey()
+        try selectingWithFieldKeyDecoable()
     }
     
     func selectingWithFieldKey() throws {
@@ -196,6 +197,50 @@ class QueryTests: XCTestCase, QueryTestType {
         
         // second row
         XCTAssertEqual(rows[1].id.id, UserID(134))
+        XCTAssertEqual(rows[1].name, name)
+        XCTAssertEqual(rows[1].age, age)
+        XCTAssertEqual(rows[1].createdAt, someDate)
+        
+        XCTAssertNotNil(rows[1].nameOptional)
+        XCTAssertNotNil(rows[1].ageOptional)
+        XCTAssertNotNil(rows[1].createdAtOptional)
+        
+        XCTAssertEqual(rows[1].nameOptional, "fuga")
+        XCTAssertEqual(rows[1].ageOptional, 50)
+        XCTAssertEqual(rows[1].createdAtOptional, anotherDate)
+        
+        XCTAssertTrue(rows[1].done)
+        XCTAssertFalse(rows[1].doneOptional!)
+    }
+    
+    func selectingWithFieldKeyDecoable() throws {
+        
+        let name = "name 's"
+        let age = 25
+        
+        typealias User = RowCodeable.UserDecodeWithKey
+        let rows:[User] = try pool.execute { conn in
+            try conn.query("SELECT * FROM ?? LIMIT ?", [constants.tableName, 2])
+        }
+        
+        XCTAssertEqual(rows.count, 2)
+        
+        // first row
+        print(rows[0])
+        XCTAssertEqual(rows[0].id, 1)
+        XCTAssertEqual(rows[0].name, name)
+        XCTAssertEqual(rows[0].age, age)
+        XCTAssertEqual(rows[0].createdAt, someDate)
+        
+        XCTAssertNil(rows[0].nameOptional)
+        XCTAssertNil(rows[0].ageOptional)
+        XCTAssertNil(rows[0].createdAtOptional)
+        
+        XCTAssertFalse(rows[0].done)
+        XCTAssertNil(rows[0].doneOptional)
+        
+        // second row
+        XCTAssertEqual(rows[1].id, 134)
         XCTAssertEqual(rows[1].name, name)
         XCTAssertEqual(rows[1].age, age)
         XCTAssertEqual(rows[1].createdAt, someDate)
@@ -261,6 +306,17 @@ class QueryTests: XCTestCase, QueryTestType {
             XCTAssertEqual(selectedUsers[index].age, row)
         }
         
+        // Test with Decodeable pattern
+        let selectedUsersCodeable: [RowCodeable.SimpleUser] = try pool.execute { conn in
+            try conn.query("SELECT id,name,age FROM ?? ORDER BY id DESC", [constants.tableName])
+        }
+        XCTAssertEqual(selectedUsersCodeable.count, 3)
+        
+        for (index, row) in (1...3).reversed().enumerated() {
+            XCTAssertEqual(selectedUsersCodeable[index].id, UInt(10+row))
+            XCTAssertEqual(selectedUsersCodeable[index].name, "name\(row)")
+            XCTAssertEqual(selectedUsersCodeable[index].age, row)
+        }
     }
     
 }


### PR DESCRIPTION
```swift
struct User: Decodable {
  let id: Int
  let user_name: String
  let age: Int?
}
let rows: [User] =  try conn.query("SELECT id, user_name FROM users WHERE id = 123")
```
See https://github.com/novi/mysql-swift/issues/58. QueryRowResultType still supported.