### PR TITLE
Correct String IDType encoding in Encodable container

### DIFF
--- a/Sources/MySQL/IDType.swift
+++ b/Sources/MySQL/IDType.swift
@@ -36,6 +36,17 @@ public func ==<T: IDType>(lhs: T, rhs: T) -> Bool {
 
 // MARK: Codable type
 
+extension IDType {
+    
+    public init(from decoder: Decoder) throws {
+        fatalError("`init(from:)` of \(Self.self) is not implemented")
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        fatalError("`encode(to:)` of \(Self.self) is not implemented")
+    }
+}
+
 extension IDType where T == Int {
     public init(from decoder: Decoder) throws {
         self.init(try decoder.singleValueContainer().decode(Int.self))
@@ -72,6 +83,17 @@ extension IDType where T == UInt {
 extension IDType where T == UInt64 {
     public init(from decoder: Decoder) throws {
         self.init(try decoder.singleValueContainer().decode(UInt64.self))
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(id)
+    }
+}
+
+extension IDType where T == String {
+    public init(from decoder: Decoder) throws {
+        self.init(try decoder.singleValueContainer().decode(String.self))
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/Sources/MySQL/QueryParameterType.swift
+++ b/Sources/MySQL/QueryParameterType.swift
@@ -47,7 +47,9 @@ public struct QueryParameterNull: QueryParameter, ExpressibleByNilLiteral {
     }
 }
 
-@available(*, renamed: "QueryDictionary")
+@available(*, renamed: "QueryParameterDictionary")
+typealias QueryDictionary = QueryParameterDictionary
+
 public struct QueryParameterDictionary: QueryParameter {
     private let dict: [String: QueryParameter?]
     public init(_ dict: [String: QueryParameter?]) {
@@ -73,7 +75,9 @@ protocol QueryParameterArrayType: QueryParameter {
     
 }
 
-@available(*, renamed: "QueryArray")
+@available(*, renamed: "QueryParameterArray")
+typealias QueryArray = QueryParameterArray
+
 public struct QueryParameterArray: QueryParameter, QueryParameterArrayType {
     private let arr: [QueryParameter?]
     public init(_ arr: [QueryParameter?]) {

--- a/Sources/MySQL/QueryParameterType.swift
+++ b/Sources/MySQL/QueryParameterType.swift
@@ -289,11 +289,11 @@ fileprivate struct QueryParameterSingleValueEncodingContainer: SingleValueEncodi
     var encoder: QueryParameterEncoder
     
     mutating func encodeNil() throws {
-        fatalError()
+        encoder.singleValue = nil
     }
     
     mutating func encode(_ value: Bool) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: Int) throws {
@@ -301,15 +301,15 @@ fileprivate struct QueryParameterSingleValueEncodingContainer: SingleValueEncodi
     }
     
     mutating func encode(_ value: Int8) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: Int16) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: Int32) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: Int64) throws {
@@ -321,15 +321,15 @@ fileprivate struct QueryParameterSingleValueEncodingContainer: SingleValueEncodi
     }
     
     mutating func encode(_ value: UInt8) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: UInt16) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: UInt32) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: UInt64) throws {
@@ -337,11 +337,11 @@ fileprivate struct QueryParameterSingleValueEncodingContainer: SingleValueEncodi
     }
     
     mutating func encode(_ value: Float) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: Double) throws {
-        fatalError()
+        encoder.singleValue = value
     }
     
     mutating func encode(_ value: String) throws {

--- a/Sources/MySQL/Result.swift
+++ b/Sources/MySQL/Result.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 
-@available(*, renamed: "SQLStringDecodable")
+@available(*, renamed: "SQLRawStringDecodable")
+typealias SQLStringDecodable = SQLRawStringDecodable
+
 internal protocol SQLRawStringDecodable {
     static func fromSQLValue(string: String) throws -> Self
 }

--- a/Tests/MySQLTests/SQLTypeTests.swift
+++ b/Tests/MySQLTests/SQLTypeTests.swift
@@ -13,6 +13,7 @@ extension SQLTypeTests {
     static var allTests : [(String, (SQLTypeTests) -> () throws -> Void)] {
         return [
                    ("testIDType", testIDType),
+                   ("testIDTypeInContainer", testIDTypeInContainer),
                     ("testEnumType", testEnumType),
                     ("testAutoincrementType", testAutoincrementType)
         ]

--- a/Tests/MySQLTests/SQLTypeTests.swift
+++ b/Tests/MySQLTests/SQLTypeTests.swift
@@ -22,11 +22,26 @@ extension SQLTypeTests {
 final class SQLTypeTests: XCTestCase {
     
     
-    struct SomeID: IDType {
+    struct IDInt: IDType {
         let id: Int
         init(_ id: Int) {
             self.id = id
         }
+    }
+    
+    struct IDString: IDType {
+        let id: String
+        init(_ id: String) {
+            self.id = id
+        }
+    }
+    
+    struct ModelWithIDType_StringAutoincrement: Encodable, QueryParameter {
+        let idStringAutoincrement: AutoincrementID<IDString>
+    }
+    
+    struct ModelWithIDType_IntAutoincrement: Encodable, QueryParameter {
+        let idIntAutoincrement: AutoincrementID<IDInt>
     }
     
     enum SomeEnumParameter: String, QueryEnumParameter {
@@ -41,11 +56,34 @@ final class SQLTypeTests: XCTestCase {
 
     func testIDType() throws {
         
-        let someID: QueryParameter = SomeID(1234)
-        XCTAssertEqual(try someID.queryParameter(option: queryOption).escaped(), "1234")
+        let idInt: QueryParameter = IDInt(1234)
+        XCTAssertEqual(try idInt.queryParameter(option: queryOption).escaped(), "1234")
         
         //let id: SomeID = try SomeID.fromSQLValue(string: "5678")
         //XCTAssertEqual(id.id, 5678)
+        
+        let idString: QueryParameter = IDString("123abc")
+        XCTAssertEqual(try idString.queryParameter(option: queryOption).escaped(), "'123abc'")
+        
+        
+        let idIntAutoincrement: QueryParameter = AutoincrementID(IDInt(1234))
+        XCTAssertEqual(try idIntAutoincrement.queryParameter(option: queryOption).escaped(), "1234")
+        
+        let idStringAutoincrement: QueryParameter = AutoincrementID(IDString("123abc"))
+        XCTAssertEqual(try idStringAutoincrement.queryParameter(option: queryOption).escaped(), "'123abc'")
+        
+    }
+    
+    func testIDTypeInContainer() throws {
+        
+        do {
+            let param: QueryParameter = ModelWithIDType_IntAutoincrement(idIntAutoincrement: .ID(IDInt(1234)))
+            XCTAssertEqual(try param.queryParameter(option: queryOption).escaped(), "`idIntAutoincrement` = 1234")
+        }
+        do {
+            let param: QueryParameter = ModelWithIDType_StringAutoincrement(idStringAutoincrement: .ID(IDString("123abc")))
+            XCTAssertEqual(try param.queryParameter(option: queryOption).escaped(), "`idStringAutoincrement` = '123abc'")
+        }
         
     }
     


### PR DESCRIPTION
Now String based IDType will be encoded correctly in Encodable container.

(And corrects wrong annotation usage.)