### PR TITLE
Fix Decimal decoding RowKeyedDecodingContainer

### DIFF
--- a/Sources/MySQL/Result.swift
+++ b/Sources/MySQL/Result.swift
@@ -269,8 +269,7 @@ fileprivate struct RowKeyedDecodingContainer<K : CodingKey> : KeyedDecodingConta
             }
             return url as! T
         } else if t == Decimal.self {
-            let doubleValue = try decoder.row.getValue(forField: key.stringValue) as Double
-            return Decimal(doubleValue) as! T
+            return try decoder.row.getValue(forField: key.stringValue) as Decimal as! T
         } else if let customType = t as? QueryRowResultCustomData.Type {
             let data = try decoder.row.getValue(forField: key.stringValue) as Data
             return try customType.decode(fromRowData: data) as! T


### PR DESCRIPTION
The string value from MySQL was converted to `Double`. In some cases this can produce strange `Decimal` values, e.g. `1.5489999999999995904` instead of `1.549`.