### PR TITLE
fix warning

### DIFF
--- a/Sources/MySQL/AutoincrementID.swift
+++ b/Sources/MySQL/AutoincrementID.swift
@@ -21,7 +21,7 @@ public enum AutoincrementID<I: IDType> {
 }
 
 extension AutoincrementID: Equatable {
-    static public func ==<I>(lhs: AutoincrementID<I>, rhs: AutoincrementID<I>) -> Bool {
+    static public func ==(lhs: AutoincrementID<I>, rhs: AutoincrementID<I>) -> Bool {
         switch (lhs, rhs) {
         case (.noID, .noID): return true
         case (.ID(let lhs), .ID(let rhs) ): return lhs.id == rhs.id

--- a/Tests/MySQLTests/MySQLConnection.swift
+++ b/Tests/MySQLTests/MySQLConnection.swift
@@ -41,7 +41,7 @@ protocol TestConstantsType: ConnectionOption {
     var tableName: String { get }
 }
 
-protocol MySQLTestType: class {
+protocol MySQLTestType: AnyObject {
     var constants: TestConstantsType! { get set }
     var pool: ConnectionPool! { get set }
 }


### PR DESCRIPTION
> [!WARNING]  
> Generic parameter 'I' shadows generic parameter from outer scope with the same name; this is an error in Swift 6

> [!WARNING]  
> Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead